### PR TITLE
Add issue templates for OKR management

### DIFF
--- a/.github/ISSUE_TEMPLATE/key-initiative.md
+++ b/.github/ISSUE_TEMPLATE/key-initiative.md
@@ -1,0 +1,12 @@
+---
+name: Initiative
+about: Initiatives are one or more tasks that make up a key result.
+title: ''
+labels: 'OKR: FY22, OKR: Key Initiative'
+assignees: ''
+
+---
+
+## Initiative Details
+
+<!--  This section is a short, but detailed description of what needs to be done for this task. -->

--- a/.github/ISSUE_TEMPLATE/key-result.md
+++ b/.github/ISSUE_TEMPLATE/key-result.md
@@ -1,0 +1,26 @@
+---
+name: Key Result
+about: A key result is the metric by which you’ll measure your progress towards your objective.
+title: ''
+labels: 'OKR: FY22, OKR: Key Result'
+assignees: ''
+
+---
+
+## Key Result Details
+
+<!--  This section is a short, but detailed description of the key result. It should include quantitative or qualitative forms of measurement. -->
+
+## KR Initiatives
+
+<!--  These are individual programs or initiatives that need to be completed to accomplish this key result -->
+
+- [ ] #ISSUE_NUMBER_GOES_HERE
+
+## Highlights
+
+<!-- Please add highlights of the key result throughout each quarter. -->
+
+## Recommendations
+
+<!-- Please add any feedback pertinent to this key result. -->

--- a/.github/ISSUE_TEMPLATE/objective.md
+++ b/.github/ISSUE_TEMPLATE/objective.md
@@ -1,0 +1,26 @@
+---
+name: Objective
+about: An objective is the overall goal you want to achieve.
+title: ''
+labels: 'OKR: FY22, OKR: Objective'
+assignees: ''
+
+---
+
+## Objective Description
+
+<!-- Define the goal you'd like to achieve (ex. increase brand awareness). -->
+
+## Key Results
+
+<!-- List the key results (GitHub issue numbers) you'd like to measure towards your goal. -->
+
+- [ ] #ISSUE_NUMBER_GOES_HERE
+
+## Highlights
+
+<!-- Please add highlights of the objective throughout each quarter. -->
+
+## Recommendations
+
+<!-- Please add any feedback pertinent to this objective. -->


### PR DESCRIPTION
Create a set of issue templates to streamline OKR creation and management. Based on the CNCF's excellent workflow templates (thanks!).

Signed-off-by: David Planella <dplanella@linuxfoundation.org>