### PR TITLE
Update handbook site URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-This handbook describes how we run the Developer Experience and Community Success team at the Linux Foundation. If you are viewing the markdown soources on the repository, you can also view the rendered documentation at [the handbook site](https://linuxfoundation.github.io/devex-and-commsuccess-handbook/). The site is generally the best URL to bookmark and share.
+This handbook describes how we run the Developer Experience and Community Success team at the Linux Foundation. If you are viewing the markdown soources on the repository, you can also view the rendered documentation at [the handbook site](https://linuxfoundation.github.io/devex-and-commsuccess/). The site is generally the best URL to bookmark and share.
 
 All team members are [encouraged to contribute to the handbook](how-to-edit-the-handbook).
 


### PR DESCRIPTION
After renaming the project, the site URL needs to be updated accordingly.

Signed-off-by: David Planella <dplanella@linuxfoundation.org>