### PR TITLE
Update Edit button URL to point to the right project

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ mermaid:
 # Footer "Edit this page on GitHub" link text
 gh_edit_link: true # show or hide edit this page link
 gh_edit_link_text: "Edit this page"
-gh_edit_repository: "https://github.com/dplanella/devex-and-commsuccess" # the github URL for your repo
+gh_edit_repository: "https://github.com/linuxfoundation/devex-and-commsuccess" # the github URL for your repo
 gh_edit_branch: "main" # the branch that your docs is served from
 # gh_edit_source: handbook # the source that your files originate from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately


### PR DESCRIPTION
Update the Edit button project URL in GitHub, so that it points to the right project instead of the fork used to create the branch with the new site.

Signed-off-by: David Planella <dplanella@linuxfoundation.org>